### PR TITLE
bug correction in pydist-cli when storing and loading config file

### DIFF
--- a/src/pydist_cli/settings.py
+++ b/src/pydist_cli/settings.py
@@ -2,29 +2,32 @@ import getpass
 import json
 import os
 
-pypi = 'https://pypi.org'
+pypi = "https://pypi.org"
 
 
 def load_settings(args):
     settings = {
-        'tag': 'default',
-        'username': None,
-        'api_key': None,
-        'index': 'https://index.pydist.com',
-        'backup_index': pypi,
+        "tag": "default",
+        "username": None,
+        "api_key": None,
+        "index": "https://index.pydist.com",
+        "backup_index": pypi,
     }
 
     # Look in .pydist.json files, with CWD taking priority.
-    home = os.environ.get('XDG_HOME') or os.environ.get('HOME')
-    home_conf_file = os.path.join(home, '.pydist.json')
-    for path in [home_conf_file, '.pydist.json']:
+    home = os.environ.get("XDG_HOME") or os.environ.get("HOME")
+    home_conf_file = os.path.join(home, ".pydist.json")
+    for path in [home_conf_file, ".pydist.json"]:
         if os.path.exists(path):
-            with open(path) as fp:
-                settings.update(json.load(fp))
+            try:
+                with open(path) as fp:
+                    settings.update(json.load(fp))
+            except json.decoder.JSONDecodeError:
+                pass  # don't load settings if file is corrupt
 
     # Handle environment variables, which take priority over file settings.
     for setting in settings:
-        env_variable = 'PYDIST_' + setting.upper()
+        env_variable = "PYDIST_" + setting.upper()
         if env_variable in os.environ:
             settings[setting] = os.environ[env_variable]
 
@@ -34,20 +37,20 @@ def load_settings(args):
         if value is not None:
             settings[setting] = value
     if args.public:
-        settings['index'] = pypi
+        settings["index"] = pypi
 
-    if settings['index'] == pypi:
-        if settings['username'] is None:
-            settings['username'] = input('PyPI username: ')
+    if settings["index"] == pypi:
+        if settings["username"] is None:
+            settings["username"] = input("PyPI username: ")
         # Always prompt for password, since the provided API key is presumably for PyDist.
         # TODO: refactor .pydist.json to save per-index credentials.
-        settings['api_key'] = getpass.getpass('PyPI password: ')
+        settings["api_key"] = getpass.getpass("PyPI password: ")
 
-    if settings['api_key'] is None and 'pydist' in settings['index']:
-        settings['api_key'] = input('PyDist API Key: ')
-        yesno = input('Save key in ~/.pydist.json? (y/N): ')
-        if yesno.lower() == 'y':
-            with open(home_conf_file, 'w') as fp:
-                json.dump(fp, settings, indent=4)
+    if settings["api_key"] is None and "pydist" in settings["index"]:
+        settings["api_key"] = input("PyDist API Key: ")
+        yesno = input("Save key in ~/.pydist.json? (y/N): ")
+        if yesno.lower() == "y":
+            with open(home_conf_file, "w") as fp:
+                json.dump(settings, fp, indent=4)
 
     return settings


### PR DESCRIPTION
pydist-cli was unusable when storing api-key because of an error in json.dump usage.
This pull-request correct the error and add a check when reading a badly formed config file (and ignore it when wrong).
